### PR TITLE
fix: assigning potential any value to the validateStatue variable

### DIFF
--- a/packages/sdk/src/helpers/request.helper.ts
+++ b/packages/sdk/src/helpers/request.helper.ts
@@ -22,7 +22,8 @@ const request = async <T>(
         'User-Agent': 'buddies-sdk'
     }
     const data = options.body ?? {}
-    const validateStatus = options.validateStatus ?? ((status) => status >= 200 && status < 300)
+    const validateStatus: (status: number) => boolean
+        = options.validateStatus ?? ((status) => status >= 200 && status < 300)
 
     const response = await axios.request<T>({
         method,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,7 +2536,7 @@ __metadata:
     "@minimouli/fs": ^2.0.1
     "@minimouli/ipc": ^2.0.0
     "@minimouli/matchers": ^2.0.0
-    "@minimouli/process": ^2.0.1
+    "@minimouli/process": ^2.0.2
     "@minimouli/types": ^2.0.0
     core-js: ^3.25.0
   languageName: unknown
@@ -2594,7 +2594,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@minimouli/process@^2.0.0, @minimouli/process@^2.0.1, @minimouli/process@workspace:packages/process":
+"@minimouli/process@^2.0.0, @minimouli/process@^2.0.2, @minimouli/process@workspace:packages/process":
   version: 0.0.0-use.local
   resolution: "@minimouli/process@workspace:packages/process"
   dependencies:


### PR DESCRIPTION
I've added a type definition for the `validateStatue` which had a potential issue with assigning an `any` value.
please take a look and let me know what do you think!