### PR TITLE
Fix/sdk-user-agent product name

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimouli/sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/packages/sdk/src/helpers/request.helper.ts
+++ b/packages/sdk/src/helpers/request.helper.ts
@@ -19,7 +19,7 @@ const request = async <T>(
         Accept: 'application/json',
         'Content-Type': 'application/json',
         ...options.headers,
-        'User-Agent': 'minimouli-sdk/1.0'
+        'User-Agent': 'minimouli-sdk'
     }
     const data = options.body ?? {}
     const validateStatus = options.validateStatus ?? ((status) => status >= 200 && status < 300)

--- a/packages/sdk/src/helpers/request.helper.ts
+++ b/packages/sdk/src/helpers/request.helper.ts
@@ -19,7 +19,7 @@ const request = async <T>(
         Accept: 'application/json',
         'Content-Type': 'application/json',
         ...options.headers,
-        'User-Agent': 'buddies-sdk'
+        'User-Agent': 'minimouli-sdk/1.0'
     }
     const data = options.body ?? {}
     const validateStatus = options.validateStatus ?? ((status) => status >= 200 && status < 300)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,7 +2536,7 @@ __metadata:
     "@minimouli/fs": ^2.0.1
     "@minimouli/ipc": ^2.0.0
     "@minimouli/matchers": ^2.0.0
-    "@minimouli/process": ^2.0.1
+    "@minimouli/process": ^2.0.2
     "@minimouli/types": ^2.0.0
     core-js: ^3.25.0
   languageName: unknown
@@ -2594,7 +2594,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@minimouli/process@^2.0.0, @minimouli/process@^2.0.1, @minimouli/process@workspace:packages/process":
+"@minimouli/process@^2.0.0, @minimouli/process@^2.0.2, @minimouli/process@workspace:packages/process":
   version: 0.0.0-use.local
   resolution: "@minimouli/process@workspace:packages/process"
   dependencies:


### PR DESCRIPTION
I noticed that the user-agent in the helper was not the right product name and did not have a version number, here is a pr setting the product name and adding the version.

I Chose `minimouli-sdk` for the product name and set the version to `1.0` please review and let me know what you think !